### PR TITLE
fix dangerouslySetInnerHtml

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,7 +255,7 @@ const element = <h1>{title}</h1>;
 ```js
 function render() {
   const value = {__html: 'First &middot; Second'};
-  return <div dangerouslySetInnerHTML={value} />;
+  return <div dangerouslySetInnerHTML={{ __html: value }} />;
 }
 ```
 


### PR DESCRIPTION
It gets harder to include plain html in latest versions of React.
According to https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml, payload of dangerouslySetInnerHtml attribute should be object with `__html` property.